### PR TITLE
Update NamespaceBranchServiceTest.java

### DIFF
--- a/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceBranchServiceTest.java
+++ b/apollo-biz/src/test/java/com/ctrip/framework/apollo/biz/service/NamespaceBranchServiceTest.java
@@ -82,7 +82,15 @@ public class NamespaceBranchServiceTest extends AbstractIntegrationTest {
     Assert.assertEquals(ReleaseOperation.APPLY_GRAY_RULES, releaseHistory.getOperation());
     Assert.assertEquals(0, releaseHistory.getReleaseId());
     Assert.assertEquals(0, releaseHistory.getPreviousReleaseId());
-    Assert.assertTrue(releaseHistory.getOperationContext().contains(rule.getRules()));
+    
+    // check that rule context items exist in the releaseHistory operations context
+    String[] ruleSplit = rule.getRules().split("[{}]");
+    ruleSplit = ruleSplit[1].split(",");
+    for (int i = 0; i < ruleSplit.length; i++)
+    {
+      Assert.assertTrue(releaseHistory.getOperationContext().contains(ruleSplit[i]));
+    }
+    
   }
 
   @Test


### PR DESCRIPTION
### Reason for Pull Request:
As it is, the testUpdateBranchGrayRulesWithUpdateOnce() test in the apollo-biz module fails on occasion due to the Stringified objects within the releaseHistory object being ordered differently than what is expected. All of the information contained within the two objects is identical except for their ordering. This ordering is not particularly important, as is seen in other PR’s submitted, so ensuring that the elements of the rules for the Stringified objects are present in the releaseHistory object is all that matters. 

### Steps to reproduce test failure:
Run test with NonDex flaky test detection tool

### Expected result: 
Test should be successful even when multiple other tests are run with it in different orderings

### Actual result:
Error:  testUpdateBranchGrayRulesWithUpdateOnce  Time elapsed: 0.27 s  <<< FAILURE! java.lang.AssertionError at org.junit.Assert.fail(Assert.java:87)

### Fix:
Get the individual strings of pieces of information within the GrayReleaseRule rule object and check that those exist within the releaseHistory object rather than comparing the two strings unaltered.
